### PR TITLE
Allow for major PHP version in composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-dom": "*",
         "ext-mbstring": "*",
         "masterminds/html5": "^2.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0",
         "symfony/options-resolver": "^3.0|^4.0|^5.0|^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8.0",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "masterminds/html5": "^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no

This update in the `composer.json` file will allow the use of PHP version 8.0 and higher. Also the version of the PSR package is updated to make it future proof. Thanks.
